### PR TITLE
fix: remove the default wildcard for catalog to force explicit declar…

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ configured only once in a `dependencySettings` extension in settings.gradle.kts.
 
 - Adds a version catalog (default name: `commonLibs`, default
   artifact: `org.hypertrace.bom:hypertrace-version-catalog:<catalogVersion>`. catalogVersion must be set explicitly)
+- Renames the default `libs` catalog (from `libs.versions.toml`) to `localLibs` to disambiguate
 - For each java project:
     - Adds dependency repositories of mavenLocal, mavenCentral, confluent and hypertrace
     - If `autoApplyBom` is specified (default: true), adds a BOM dependency to the `api` configuration (falling back
@@ -26,6 +27,7 @@ Example usage in `settings.gradle.kts`:
     plugins {
       id("org.hypertrace.dependency-settings") version "0.1.0"
     }
+
 
     configure<DependencyPluginSettingExtension> {
       catalogVersion.set("0.1.0")

--- a/README.md
+++ b/README.md
@@ -9,15 +9,25 @@ Certain values are configurable via `dependencySettings` extension inside each p
 configured only once in a `dependencySettings` extension in settings.gradle.kts.
 
 - Adds a version catalog (default name: `commonLibs`, default
-  artifact: `org.hypertrace.bom:hypertrace-version-catalog:+`)
+  artifact: `org.hypertrace.bom:hypertrace-version-catalog:<catalogVersion>`. catalogVersion must be set explicitly)
 - For each java project:
     - Adds dependency repositories of mavenLocal, mavenCentral, confluent and hypertrace
     - If `autoApplyBom` is specified (default: true), adds a BOM dependency to the `api` configuration (falling back
       to `implementation` if `api` is unavailable). The BOM reference to use (`bomArtifactName` -
       default `hypertrace.bom`) and version can also be configured. `bomVersionName` (defaults to `hypertrace.bom`)
-      describes the name of the version property in the catalog and `bomVersion` (defaults to `catalogVersion` , which
-      itself defaults to latest) describes the value to assign.
+      describes the name of the version property in the catalog and `bomVersion` (defaults to latest - `+`) describes the value to assign.
     - If `useDependencyLocking` is specified (default: true), configures strict dependency locking on certain
       configurations (default: `annotationProcessor`, `compileClasspath`, `runtimeClasspath`)
     - If `useDependencyLocking` is specified (default: true), adds a project task `resolveAndLockAll`which can be use in
       conjunction with the `--write-locks` flag to update all project lockfiles.
+
+Example usage in `settings.gradle.kts`:
+```kts
+    plugins {
+      id("org.hypertrace.dependency-settings") version "0.1.0"
+    }
+
+    configure<DependencyPluginSettingExtension> {
+      catalogVersion.set("0.1.0")
+    }
+```

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/gradlew
+++ b/gradlew
@@ -145,7 +145,7 @@ if ! "$cygwin" && ! "$darwin" && ! "$nonstop" ; then
     case $MAX_FD in #(
       max*)
         # In POSIX sh, ulimit -H is undefined. That's why the result is checked to see if it worked.
-        # shellcheck disable=SC3045
+        # shellcheck disable=SC2039,SC3045
         MAX_FD=$( ulimit -H -n ) ||
             warn "Could not query maximum file descriptor limit"
     esac
@@ -153,7 +153,7 @@ if ! "$cygwin" && ! "$darwin" && ! "$nonstop" ; then
       '' | soft) :;; #(
       *)
         # In POSIX sh, ulimit -n is undefined. That's why the result is checked to see if it worked.
-        # shellcheck disable=SC3045
+        # shellcheck disable=SC2039,SC3045
         ulimit -n "$MAX_FD" ||
             warn "Could not set maximum file descriptor limit to $MAX_FD"
     esac
@@ -202,11 +202,11 @@ fi
 # Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
 DEFAULT_JVM_OPTS='"-Xmx64m" "-Xms64m"'
 
-# Collect all arguments for the java command;
-#   * $DEFAULT_JVM_OPTS, $JAVA_OPTS, and $GRADLE_OPTS can contain fragments of
-#     shell script including quotes and variable substitutions, so put them in
-#     double quotes to make sure that they get re-expanded; and
-#   * put everything else in single quotes, so that it's not re-expanded.
+# Collect all arguments for the java command:
+#   * DEFAULT_JVM_OPTS, JAVA_OPTS, JAVA_OPTS, and optsEnvironmentVar are not allowed to contain shell fragments,
+#     and any embedded shellness will be escaped.
+#   * For example: A user cannot expect ${Hostname} to be expanded, as it is an environment variable and will be
+#     treated as '${Hostname}' itself on the command line.
 
 set -- \
         "-Dorg.gradle.appname=$APP_BASE_NAME" \

--- a/src/main/java/org/hypertrace/gradle/dependency/DependencyPluginSettingExtension.java
+++ b/src/main/java/org/hypertrace/gradle/dependency/DependencyPluginSettingExtension.java
@@ -12,6 +12,7 @@ public class DependencyPluginSettingExtension {
   private static final String DEFAULT_CATALOG_NAME = "commonLibs";
   private static final String DEFAULT_BOM_ARTIFACT_NAME = "hypertrace.bom";
   private static final String DEFAULT_BOM_VERSION_NAME = "hypertrace.bom";
+  private static final String DEFAULT_BOM_VERSION = "+";
   private static final boolean DEFAULT_USE_DEPENDENCY_LOCKING = true;
 
   public final Property<String> catalogGroup;
@@ -42,7 +43,7 @@ public class DependencyPluginSettingExtension {
     this.bomArtifactName.disallowUnsafeRead();
     this.bomVersionName = objectFactory.property(String.class).convention(DEFAULT_BOM_VERSION_NAME);
     this.bomVersionName.disallowUnsafeRead();
-    this.bomVersion = objectFactory.property(String.class).convention(this.catalogVersion);
+    this.bomVersion = objectFactory.property(String.class).convention(DEFAULT_BOM_VERSION);
     this.bomVersion.disallowUnsafeRead();
   }
 

--- a/src/main/java/org/hypertrace/gradle/dependency/DependencyPluginSettingExtension.java
+++ b/src/main/java/org/hypertrace/gradle/dependency/DependencyPluginSettingExtension.java
@@ -9,7 +9,6 @@ public class DependencyPluginSettingExtension {
   static final String EXTENSION_NAME = "dependencySettings";
   private static final String DEFAULT_CATALOG_GROUP = "org.hypertrace.bom";
   private static final String DEFAULT_CATALOG_ARTIFACT = "hypertrace-version-catalog";
-  private static final String DEFAULT_CATALOG_VERSION = "+";
   private static final String DEFAULT_CATALOG_NAME = "commonLibs";
   private static final String DEFAULT_BOM_ARTIFACT_NAME = "hypertrace.bom";
   private static final String DEFAULT_BOM_VERSION_NAME = "hypertrace.bom";
@@ -31,7 +30,7 @@ public class DependencyPluginSettingExtension {
     this.catalogArtifact =
         objectFactory.property(String.class).convention(DEFAULT_CATALOG_ARTIFACT);
     this.catalogArtifact.disallowUnsafeRead();
-    this.catalogVersion = objectFactory.property(String.class).convention(DEFAULT_CATALOG_VERSION);
+    this.catalogVersion = objectFactory.property(String.class);
     this.catalogVersion.disallowUnsafeRead();
     this.catalogName = objectFactory.property(String.class).convention(DEFAULT_CATALOG_NAME);
     this.catalogName.disallowUnsafeRead();

--- a/src/main/java/org/hypertrace/gradle/dependency/HypertraceDependencySettingsPlugin.java
+++ b/src/main/java/org/hypertrace/gradle/dependency/HypertraceDependencySettingsPlugin.java
@@ -29,6 +29,7 @@ public class HypertraceDependencySettingsPlugin implements Plugin<Settings> {
         .getGradle()
         .settingsEvaluated(
             unused -> {
+              this.updateLocalCatalogNameConvention(settings);
               this.addDependencyRepositories(settings);
               this.addVersionCatalog(settings, settingExtension);
             });
@@ -67,6 +68,14 @@ public class HypertraceDependencySettingsPlugin implements Plugin<Settings> {
         .create(
             DependencyPluginProjectExtension.EXTENSION_NAME,
             DependencyPluginProjectExtension.class);
+  }
+
+  private void updateLocalCatalogNameConvention(Settings settings) {
+    // Update convention to make it clear which libs are local and which come from common catalog
+    settings
+        .getDependencyResolutionManagement()
+        .getDefaultLibrariesExtensionName()
+        .convention("localLibs");
   }
 
   /**

--- a/src/main/java/org/hypertrace/gradle/dependency/HypertraceDependencySettingsPlugin.java
+++ b/src/main/java/org/hypertrace/gradle/dependency/HypertraceDependencySettingsPlugin.java
@@ -157,6 +157,10 @@ public class HypertraceDependencySettingsPlugin implements Plugin<Settings> {
               dependencyResolutionManagement
                   .getVersionCatalogs()
                   .create(settingExtension.catalogName.get());
+          if (!settingExtension.catalogVersion.isPresent()) {
+            throw new GradleException(
+                "catalogVersion must be set in your settings.gradle.kts file. See https://github.com/hypertrace/hypertrace-gradle-dependency-settings-plugin/blob/main/README.md for details");
+          }
           catalogBuilder.from(settingExtension.getCatalogArtifactNotation().get());
           catalogBuilder.version(
               settingExtension.bomVersionName.get(), settingExtension.bomVersion.get());


### PR DESCRIPTION
See https://github.com/hypertrace/github-actions/pull/33/files#r1373931670 for details, but tl;dr - it's challenging to support locking a wildcard catalog version, and without locking we don't want to use wildcards.