### PR TITLE
fix: try to delete the settings lockfile automatically

### DIFF
--- a/src/main/java/org/hypertrace/gradle/dependency/DeleteSettingsLockfileAction.java
+++ b/src/main/java/org/hypertrace/gradle/dependency/DeleteSettingsLockfileAction.java
@@ -1,0 +1,26 @@
+package org.hypertrace.gradle.dependency;
+
+import java.io.File;
+import javax.annotation.Nonnull;
+import javax.inject.Inject;
+import org.gradle.api.file.FileSystemOperations;
+import org.gradle.api.flow.FlowAction;
+import org.gradle.api.flow.FlowParameters;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.hypertrace.gradle.dependency.DeleteSettingsLockfileAction.Parameters;
+
+public abstract class DeleteSettingsLockfileAction implements FlowAction<Parameters> {
+  interface Parameters extends FlowParameters {
+    @Input
+    Property<File> getDeleteTarget();
+  }
+
+  @Inject
+  protected abstract FileSystemOperations getFileSystemOperations();
+
+  @Override
+  public void execute(@Nonnull Parameters parameters) {
+    getFileSystemOperations().delete(spec -> spec.delete(parameters.getDeleteTarget()));
+  }
+}

--- a/src/main/java/org/hypertrace/gradle/dependency/DependencyPluginSettingExtension.java
+++ b/src/main/java/org/hypertrace/gradle/dependency/DependencyPluginSettingExtension.java
@@ -13,13 +13,12 @@ public class DependencyPluginSettingExtension {
   private static final String DEFAULT_BOM_ARTIFACT_NAME = "hypertrace.bom";
   private static final String DEFAULT_BOM_VERSION_NAME = "hypertrace.bom";
   private static final String DEFAULT_BOM_VERSION = "+";
-  private static final boolean DEFAULT_USE_DEPENDENCY_LOCKING = true;
 
   public final Property<String> catalogGroup;
   public final Property<String> catalogArtifact;
   public final Property<String> catalogVersion;
   public final Property<String> catalogName;
-  public final Property<Boolean> useDependencyLocking;
+  public final Property<DependencyLockingMode> dependencyLockMode;
   public final Property<String> bomArtifactName;
   public final Property<String> bomVersionName;
   public final Property<String> bomVersion;
@@ -35,9 +34,11 @@ public class DependencyPluginSettingExtension {
     this.catalogVersion.disallowUnsafeRead();
     this.catalogName = objectFactory.property(String.class).convention(DEFAULT_CATALOG_NAME);
     this.catalogName.disallowUnsafeRead();
-    this.useDependencyLocking =
-        objectFactory.property(Boolean.class).convention(DEFAULT_USE_DEPENDENCY_LOCKING);
-    this.useDependencyLocking.disallowUnsafeRead();
+    this.dependencyLockMode =
+        objectFactory
+            .property(DependencyLockingMode.class)
+            .convention(DependencyLockingMode.PROJECTS_ONLY);
+    this.dependencyLockMode.disallowUnsafeRead();
     this.bomArtifactName =
         objectFactory.property(String.class).convention(DEFAULT_BOM_ARTIFACT_NAME);
     this.bomArtifactName.disallowUnsafeRead();
@@ -56,5 +57,11 @@ public class DependencyPluginSettingExtension {
                         versionString ->
                             String.format(
                                 "%s:%s:%s", groupString, artifactString, versionString))));
+  }
+
+  public enum DependencyLockingMode {
+    DISABLED,
+    PROJECTS_ONLY, // Default
+    PROJECTS_AND_SETTINGS // Typically not desired due to bugs in the settings lock.
   }
 }


### PR DESCRIPTION
## Description

I'm trying to find a way so the settings-gradle.lockfile that is generated can be ignored... The issue is that it's read in first thing (e.g. can't delete it in time at beginning of build) and written out last (no hooks to delete after written).

This attempt was the closest I can come up with - it deletes the file at the end of the build, but that still means it'll show up if writing locks until the following build. Leaving this in draft right now until I can come up with better way (open to suggestions!)
