### PR TITLE
build: update locking to lock test classpaths by default too

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,32 +4,42 @@
 
 ### Purpose
 
-This plugin configures various aspects of dependency management. Where values are configurable, a default is specified.
-Certain values are configurable via `dependencySettings` extension inside each project build.gradle.kts, but most are
+This plugin configures various aspects of dependency management. Where values are configurable, a
+default is specified.
+Certain values are configurable via `dependencySettings` extension inside each project
+build.gradle.kts, but most are
 configured only once in a `dependencySettings` extension in settings.gradle.kts.
 
 - Adds a version catalog (default name: `commonLibs`, default
-  artifact: `org.hypertrace.bom:hypertrace-version-catalog:<catalogVersion>`. catalogVersion must be set explicitly)
+  artifact: `org.hypertrace.bom:hypertrace-version-catalog:<catalogVersion>`. catalogVersion must be
+  set explicitly)
 - Renames the default `libs` catalog (from `libs.versions.toml`) to `localLibs` to disambiguate
 - For each java project:
     - Adds dependency repositories of mavenLocal, mavenCentral, confluent and hypertrace
-    - If `autoApplyBom` is specified (default: true), adds a BOM dependency to the `api` configuration (falling back
+    - If `autoApplyBom` is specified (default: true), adds a BOM dependency to the `api`
+      configuration (falling back
       to `implementation` if `api` is unavailable). The BOM reference to use (`bomArtifactName` -
-      default `hypertrace.bom`) and version can also be configured. `bomVersionName` (defaults to `hypertrace.bom`)
-      describes the name of the version property in the catalog and `bomVersion` (defaults to latest - `+`) describes the value to assign.
-    - If `useDependencyLocking` is specified (default: true), configures strict dependency locking on certain
-      configurations (default: `annotationProcessor`, `compileClasspath`, `runtimeClasspath`)
-    - If `useDependencyLocking` is specified (default: true), adds a project task `resolveAndLockAll`which can be use in
+      default `hypertrace.bom`) and version can also be configured. `bomVersionName` (defaults
+      to `hypertrace.bom`)
+      describes the name of the version property in the catalog and `bomVersion` (defaults to
+      latest - `+`) describes the value to assign.
+    - If `useDependencyLocking` is specified (default: true), configures strict dependency locking
+      on certain
+      configurations (
+      default: `annotationProcessor`, `compileClasspath`, `runtimeClasspath`, `testCompileClasspath`, `testRuntimeClasspath`)
+    - If `useDependencyLocking` is specified (default: true), adds a project
+      task `resolveAndLockAll`which can be use in
       conjunction with the `--write-locks` flag to update all project lockfiles.
 
 Example usage in `settings.gradle.kts`:
+
 ```kts
     plugins {
-      id("org.hypertrace.dependency-settings") version "0.1.0"
-    }
+  id("org.hypertrace.dependency-settings") version "0.1.0"
+}
 
 
-    configure<DependencyPluginSettingExtension> {
-      catalogVersion.set("0.1.0")
-    }
+configure<DependencyPluginSettingExtension> {
+  catalogVersion.set("0.1.0")
+}
 ```

--- a/src/main/java/org/hypertrace/gradle/dependency/DependencyPluginProjectExtension.java
+++ b/src/main/java/org/hypertrace/gradle/dependency/DependencyPluginProjectExtension.java
@@ -14,7 +14,9 @@ public class DependencyPluginProjectExtension {
       List.of(
           JavaPlugin.ANNOTATION_PROCESSOR_CONFIGURATION_NAME,
           JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME,
-          JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME);
+          JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME,
+          JavaPlugin.TEST_COMPILE_CLASSPATH_CONFIGURATION_NAME,
+          JavaPlugin.TEST_RUNTIME_CLASSPATH_CONFIGURATION_NAME);
   public final ListProperty<String> configurationsToLock;
 
   public final Property<Boolean> autoApplyBom;


### PR DESCRIPTION
## Description

Added test compile and runtime classpaths to default locking. Previously, the dynamic bom was locked for runtime but not tests.